### PR TITLE
Adding AWSCLI version to requirements to avoid pip getting too high a…

### DIFF
--- a/requirements-logger.txt
+++ b/requirements-logger.txt
@@ -1,3 +1,4 @@
+awscli>=1.24.10
 boto3>=1.26
 ipynbname>=2021.3.2
 nbformat>=5.7.3


### PR DESCRIPTION
… version of botocore

Currently in the gradient repos at [v2.2](https://github.com/graphcore/Gradient-Pytorch-Geometric/commit/794f9fa2da269ace5715d5e4d2bd7abc6f827918) when installing the examples_utils @ [latest stable](https://github.com/graphcore/examples-utils/commit/40c62e6646db8f9d60d1707a61204c95a15c7ccb), we get no issues from pip, and it says:
```
Requirement already satisfied: awscli>=1.24.10 in /usr/local/lib/python3.8/dist-packages (from examples-utils[common]@ git+https://github.com/graphcore/examples-utils@latest_stable->-r requirements.txt (line 4)) (1.27.143)
```

Indicating the existing version in the container is fine (tested this with no other packages in requirements file, so it cant be an indirect dependency) 

However in graphcore cloud tools, when using the graident repos at [master](https://github.com/graphcore/graphcore-cloud-tools/commit/721bf07f0e7a9607e729500d30a921f822b58e62) (for PyG for example) pip now throws:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
awscli 1.27.143 requires botocore==1.29.143, but you have botocore 1.31.1 which is incompatible.
```

It seems like the only difference is that in the old version of the loggers requirements, awscli is specified as: `awscli>=1.24.10`, which makes it ok to use the existing version of botocore and prevents pip from getting the latest version causing this clash?

More investigation pending to figure out exactly whats going on, but this does atleast fix the issue for now.