### PR TITLE
add option to retry downloading failed files from s3

### DIFF
--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -428,7 +428,7 @@ def copy_graphcore_s3(args):
 
         #RRR testing - to be removed
         if attempt == 0:
-            errors = {["failed_file_downloads"]:"rrr"}
+            errors = {"failed_file_downloads":["rrr"]}
             local_file = '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef'
             assert os.path.isfile(local_file)
 

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -426,6 +426,18 @@ def copy_graphcore_s3(args):
             failed_files=failed_files
         )
 
+        #RRR testing - to be removed
+        if attempt == 0:
+            errors = {["failed_file_downloads"]:"rrr"}
+            import os
+            local_file = '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef'
+            assert os.path.isfile(local_file)
+
+            failed_files = [GradientDatasetFile(s3file='graphcore-gradient-datasets/poplar-executables-pytorch-3-3/3.3.0/kge_training/4253143966390608402.popef', local_file=local_file, size=4399398296)]
+        else:
+            assert os.path.isfile(local_file)
+        #RRR testing end
+
         if errors:
             # add and label errors from different attempts
             if attempt == 0:

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -307,12 +307,16 @@ def download_file(
                     raise S3DownloadFailed(f"Command {cmd} failed with return code {out.returncode}")
             # successful download - clear failed errors from previous attempts and break
             if attempt > 0:
-                # Only print on multiple attempts to not clutter the log. 
-                print(f"Successfully downloaded file {file} after multiple attempts, on attempt nr {attempt+1}/{max_attempts}")
+                # Only print on multiple attempts to not clutter the log.
+                print(
+                    f"Successfully downloaded file {file} after multiple attempts, on attempt nr {attempt+1}/{max_attempts}"
+                )
             exceptions = []
             break
         except Exception as error:
-            print(f"[WARNING] Failed to download file {file} on attempt {attempt+1}/{max_attempts} with error: {type(error).__name__} {error}.")
+            print(
+                f"[WARNING] Failed to download file {file} on attempt {attempt+1}/{max_attempts} with error: {type(error).__name__} {error}."
+            )
             exceptions.append(error)
             if attempt + 1 < max_attempts:
                 print(f"Retrying download of file {file} - attempt {attempt+2}/{max_attempts}...")

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -305,9 +305,9 @@ def download_file(
             exceptions.append(error)
             if attempt + 1 < max_attempts:
                 print(f"Failed to download file {file}. Retrying - attempt {attempt+2}/{max_attempts}...")
+                time.sleep(1)
             else: 
                 print(f"All {max_attempts} attempts exhausted - failed to download file {file}.")
-            time.sleep(1)
     elapsed = time.time() - start
     size_gb = file.size / (1024**3)
     print(f"Finished {progress}: {size_gb:.2f}GB in {elapsed:.0f}s ({size_gb/elapsed:.3f} GB/s) for file {target}")

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -429,7 +429,6 @@ def copy_graphcore_s3(args):
         #RRR testing - to be removed
         if attempt == 0:
             errors = {["failed_file_downloads"]:"rrr"}
-            import os
             local_file = '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef'
             assert os.path.isfile(local_file)
 

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -305,6 +305,15 @@ def download_file(
                 out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
                 if out.returncode != 0:
                     raise S3DownloadFailed(f"Command {cmd} failed with return code {out.returncode}")
+            #RRR testing - to be removed
+            if file.local_file == '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef':
+                if attempt == 0:
+                    assert os.path.isfile(file.local_file)
+                    os.remove(file.local_file)
+                    raise Exception
+                else:
+                    assert os.path.isfile(file.local_file)
+            #RRR testing end
             # successful download - clear failed errors from previous attempts and break
             exceptions = []
             break

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -431,7 +431,7 @@ def copy_graphcore_s3(args):
             errors = {"failed_file_downloads":["rrr"]}
             local_file = '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef'
             assert os.path.isfile(local_file)
-
+            os.remove(local_file)
             failed_files = [GradientDatasetFile(s3file='graphcore-gradient-datasets/poplar-executables-pytorch-3-3/3.3.0/kge_training/4253143966390608402.popef', local_file=local_file, size=4399398296)]
         else:
             assert os.path.isfile(local_file)

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -305,15 +305,6 @@ def download_file(
                 out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
                 if out.returncode != 0:
                     raise S3DownloadFailed(f"Command {cmd} failed with return code {out.returncode}")
-            #RRR testing - to be removed
-            if file.local_file == '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef':
-                # if attempt == 0:
-                assert os.path.isfile(file.local_file)
-                os.remove(file.local_file)
-                raise Exception
-                # else:
-                #     assert os.path.isfile(file.local_file)
-            #RRR testing end
             # successful download - clear failed errors from previous attempts and break
             exceptions = []
             break

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -307,12 +307,12 @@ def download_file(
                     raise S3DownloadFailed(f"Command {cmd} failed with return code {out.returncode}")
             #RRR testing - to be removed
             if file.local_file == '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef':
-                if attempt == 0:
-                    assert os.path.isfile(file.local_file)
-                    os.remove(file.local_file)
-                    raise Exception
-                else:
-                    assert os.path.isfile(file.local_file)
+                # if attempt == 0:
+                assert os.path.isfile(file.local_file)
+                os.remove(file.local_file)
+                raise Exception
+                # else:
+                #     assert os.path.isfile(file.local_file)
             #RRR testing end
             # successful download - clear failed errors from previous attempts and break
             exceptions = []

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -291,7 +291,7 @@ def download_file(
     target.parent.mkdir(exist_ok=True, parents=True)
     exceptions = []
 
-    for attempt in max_attempts:
+    for attempt in range(max_attempts):
         try:
             if not use_cli:
                 s3client.download_file(bucket_name, file.s3file, str(target), Config=config)

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -273,7 +273,14 @@ def download_file_iterate_endpoints(aws_endpoints: List[str], *args, **kwargs) -
 
 
 def download_file(
-    aws_endpoint: str, aws_credential, file: GradientDatasetFile, *, max_concurrency, use_cli, progress="", max_attempts=2
+    aws_endpoint: str,
+    aws_credential,
+    file: GradientDatasetFile,
+    *,
+    max_concurrency,
+    use_cli,
+    progress="",
+    max_attempts=2,
 ) -> DownloadOutput:
     bucket_name = "sdk"
     s3client = boto3.Session(profile_name=aws_credential).client("s3", endpoint_url=aws_endpoint)
@@ -298,7 +305,7 @@ def download_file(
                 out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
                 if out.returncode != 0:
                     raise S3DownloadFailed(f"Command {cmd} failed with return code {out.returncode}")
-            #successful download - clear failed errors from previous attempts and break
+            # successful download - clear failed errors from previous attempts and break
             exceptions = []
             break
         except Exception as error:
@@ -306,7 +313,7 @@ def download_file(
             if attempt + 1 < max_attempts:
                 print(f"Failed to download file {file}. Retrying - attempt {attempt+2}/{max_attempts}...")
                 time.sleep(1)
-            else: 
+            else:
                 print(f"All {max_attempts} attempts exhausted - failed to download file {file}.")
     elapsed = time.time() - start
     size_gb = file.size / (1024**3)
@@ -424,9 +431,9 @@ def copy_graphcore_s3(args):
     )
     if errors:
         raise RuntimeError(
-                "There were errors during the dataset download from S3, check below for details."
-                f"\nerrors: {errors}\nArguments were: {args}\ndatasets: {datasets}\nconfig: {symlink_config}"
-            )
+            "There were errors during the dataset download from S3, check below for details."
+            f"\nerrors: {errors}\nArguments were: {args}\ndatasets: {datasets}\nconfig: {symlink_config}"
+        )
 
 
 def symlink_arguments(parser=argparse.ArgumentParser()) -> argparse.ArgumentParser:
@@ -444,9 +451,7 @@ def symlink_arguments(parser=argparse.ArgumentParser()) -> argparse.ArgumentPars
         default=str(Path(".").resolve().parent / "settings.yaml"),
         help="Path to gradient settings.yaml file",
     )
-    parser.add_argument(
-        "--max-attempts", default=2, type=int, help="Maximum number of s3 download attempts per file"
-    )
+    parser.add_argument("--max-attempts", default=2, type=int, help="Maximum number of s3 download attempts per file")
     parser.add_argument("--public-endpoint", action="store_true", help="Use endpoint fallback")
     parser.add_argument("--disable-legacy-mode", action="store_true", help="block attempts to use legacy mode")
     return parser

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -427,17 +427,6 @@ def copy_graphcore_s3(args):
             failed_files=failed_files,
         )
 
-        #RRR testing - to be removed
-        if attempt == 0:
-            errors = {"failed_file_downloads":["rrr"]}
-            local_file = '/tmp/exe_cache/3.3.0/kge_training/4253143966390608402.popef'
-            assert os.path.isfile(local_file)
-            os.remove(local_file)
-            failed_files = [GradientDatasetFile(s3file='graphcore-gradient-datasets/poplar-executables-pytorch-3-3/3.3.0/kge_training/4253143966390608402.popef', local_file=local_file, size=4399398296)]
-        else:
-            assert os.path.isfile(local_file)
-        #RRR testing end
-
         if errors:
             # add and label errors from different attempts
             if attempt == 0:

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -313,7 +313,7 @@ def parallel_download_dataset_from_s3(
     symlink=True,
     use_cli=False,
     endpoint_fallback=False,
-    failed_files: List[GradientDatasetFile]=None,
+    failed_files: List[GradientDatasetFile] = None,
 ) -> Tuple[List[GradientDatasetFile], Dict[str, List[str]]]:
     aws_credential = "gcdata-r"
     aws_endpoints = get_valid_aws_endpoints(endpoint_fallback)
@@ -415,7 +415,7 @@ def copy_graphcore_s3(args):
     failed_files = []
     all_attempts_errors = {}
 
-    for attempt in range(1 + max_retries): # Including the initial attempt
+    for attempt in range(1 + max_retries):  # Including the initial attempt
         _, errors, failed_files = parallel_download_dataset_from_s3(
             datasets,
             symlink_config,
@@ -423,7 +423,7 @@ def copy_graphcore_s3(args):
             num_concurrent_downloads=args.num_concurrent_downloads,
             symlink=not args.no_symlink,
             endpoint_fallback=args.public_endpoint,
-            failed_files=failed_files
+            failed_files=failed_files,
         )
 
         if errors:
@@ -431,14 +431,16 @@ def copy_graphcore_s3(args):
             if attempt == 0:
                 all_attempts_errors = errors
             else:
-                key_suffix = f"_retry_{attempt}" 
+                key_suffix = f"_retry_{attempt}"
                 for key, value in errors.items():
                     all_attempts_errors[f"{key}{key_suffix}"] = value
 
             if failed_files:
                 # retry download failed files
                 if attempt < max_retries:
-                    print(f"Retry attempt {attempt+1}/{max_retries}: Retrying download for {len(failed_files)} failed files...") 
+                    print(
+                        f"Retry attempt {attempt+1}/{max_retries}: Retrying download for {len(failed_files)} failed files..."
+                    )
                 else:
                     print(f"All {max_retries} retries exhausted. Failed to download {len(failed_files)} files.")
             else:
@@ -448,7 +450,11 @@ def copy_graphcore_s3(args):
             # Successful download. Remove any "failed files" errors from previous unsuccessful attempts.
             # There may still be other errors like missing datasets that will be raised
             if any(key.startswith("failed_file_downloads") for key in all_attempts_errors):
-                all_attempts_errors = {key: value for key, value in all_attempts_errors.items() if not key.startswith("failed_file_downloads")}
+                all_attempts_errors = {
+                    key: value
+                    for key, value in all_attempts_errors.items()
+                    if not key.startswith("failed_file_downloads")
+                }
             break
     if all_attempts_errors:
         raise RuntimeError(
@@ -472,7 +478,9 @@ def symlink_arguments(parser=argparse.ArgumentParser()) -> argparse.ArgumentPars
         default=str(Path(".").resolve().parent / "settings.yaml"),
         help="Path to gradient settings.yaml file",
     )
-    parser.add_argument("--max-retries", default=1, type=int, help="Maximum number of download retries in case of failures")
+    parser.add_argument(
+        "--max-retries", default=1, type=int, help="Maximum number of download retries in case of failures"
+    )
     parser.add_argument("--public-endpoint", action="store_true", help="Use endpoint fallback")
     parser.add_argument("--disable-legacy-mode", action="store_true", help="block attempts to use legacy mode")
     return parser

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -326,7 +326,8 @@ def parallel_download_dataset_from_s3(
         # reattempt to download failed files
         files_to_download = failed_files
         failed_datasets = []
-        print(f"Retrying download of {len(files_to_download)} failed files: {files_to_download}")
+        num_files = len(files_to_download)
+        print(f"Retrying download of {num_files} failed files: {files_to_download}")
     else:
         files_to_download: List[GradientDatasetFile] = []
 

--- a/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
+++ b/graphcore_cloud_tools/paperspace_utils/symlink_datasets_and_caches.py
@@ -490,7 +490,7 @@ def symlink_arguments(parser=argparse.ArgumentParser()) -> argparse.ArgumentPars
         help="Path to gradient settings.yaml file",
     )
     parser.add_argument(
-        "--max-retries", default=1, type=int, help="Maximum number of download retries in case of failures"
+        "--max-retries", default=1, type=int, help="Maximum number of s3 download retries in case of failures"
     )
     parser.add_argument("--public-endpoint", action="store_true", help="Use endpoint fallback")
     parser.add_argument("--disable-legacy-mode", action="store_true", help="block attempts to use legacy mode")

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -209,5 +209,5 @@ def test_s3_linking(monkeypatch, s3_datasets, settings_file, symlink_config, cap
             endpoint_fallback=False,
         )
 
-    source_dirs_exist_paths, errors, failed_files = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
+    source_dirs_exist_paths, errors = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
     assert not errors

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -209,5 +209,5 @@ def test_s3_linking(monkeypatch, s3_datasets, settings_file, symlink_config, cap
             endpoint_fallback=False,
         )
 
-    source_dirs_exist_paths, errors = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
+    source_dirs_exist_paths, errors, failed_files = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
     assert not errors

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -209,5 +209,7 @@ def test_s3_linking(monkeypatch, s3_datasets, settings_file, symlink_config, cap
             endpoint_fallback=False,
         )
 
-    source_dirs_exist_paths, errors, failed_files = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
+    source_dirs_exist_paths, errors, failed_files = check_files_are_visible_in_symlink_folder(
+        function_under_test, symlink_config
+    )
     assert not errors

--- a/tests/test_symlink.py
+++ b/tests/test_symlink.py
@@ -212,6 +212,7 @@ def test_s3_linking(monkeypatch, s3_datasets, settings_file, symlink_config, cap
     source_dirs_exist_paths, errors = check_files_are_visible_in_symlink_folder(function_under_test, symlink_config)
     assert not errors
 
+
 def test_s3_retry_download(monkeypatch, s3_datasets):
     config_file, endpoint_url = s3_datasets
     monkeypatch.setenv(symlink_datasets_and_caches.AWS_ENDPOINT_ENV_VAR, endpoint_url)
@@ -223,17 +224,18 @@ def test_s3_retry_download(monkeypatch, s3_datasets):
     source_folder = config[target_folder][0]
     nonexistent_source = f"{source_folder}/nonexistent.txt"
     nonexistent_file = symlink_datasets_and_caches.GradientDatasetFile(
-        s3file=nonexistent_source, 
-        local_file=nonexistent_target
+        s3file=nonexistent_source, local_file=nonexistent_target
     )
-    
-    aws_endpoint=symlink_datasets_and_caches.get_valid_aws_endpoints()[0]
-    max_attempts=2
-    out = symlink_datasets_and_caches.download_file(aws_endpoint, 
-                                                    aws_credential="gcdata-r", 
-                                                    file=nonexistent_file, 
-                                                    max_concurrency=1,
-                                                    use_cli=False,
-                                                    progress="1/1",
-                                                    max_attempts=max_attempts)
+
+    aws_endpoint = symlink_datasets_and_caches.get_valid_aws_endpoints()[0]
+    max_attempts = 2
+    out = symlink_datasets_and_caches.download_file(
+        aws_endpoint,
+        aws_credential="gcdata-r",
+        file=nonexistent_file,
+        max_concurrency=1,
+        use_cli=False,
+        progress="1/1",
+        max_attempts=max_attempts,
+    )
     assert len(out.errors) == max_attempts


### PR DESCRIPTION
We've seen in CI that we encounter some 'connection reset' errors when downloading from s3. In those cases, it seems to affect a few files (< 5) at a time, but so far without affecting the result of the notebook run. This may be due to overloading the endpoint, or DMZ network issues. Stuart has made adjustments to the s3 proxy VM to try to mitigate. But at the same time, this PR makes a change to the existing download script to attempt a retry if there are failures. 

Changes made
- There is a `max-retries` command line arg (default 1)
- `parallel_download_dataset_from_s3` accepts a `failed_files` arg which is None by default. If not None, the function will only try to download those files, rather than all the datasets in settings.yaml.
- Errors from each attempt are accumulated in a `all_attempts_errors` which is what is raised if all attempts are unsuccessful. 
- We only retry the download if there are failed files, not if there are missing datasets. 
- If there are failed files from an earlier attempt that are successful in a later attempt, we don't raise the previous error. In these cases, we'd still raise a RuntimeError only if a different **type** of error occurred in the first attempt, like a missing dataset. If all attempts fail then errors from all attempts are printed/raised. 

Testing:
All the tests below are from inspecting the s3 download in `prepare-datasets.sh`

- CI run (successful on first download attempt) - https://github.com/graphcore/Gradient-Pytorch-private/actions/runs/6237782767
- CI run forcing retry download of 1 file - https://github.com/graphcore/Gradient-Pytorch-private/actions/runs/6238473814/job/16934381394. 
 @payoto in the second CI run's logs I noticed the following lines, just wanted to check if it was expected
```
NB 09a61: End point cannot be reached from current executor: http://10.194.16.183:8300/
NB 09a61: Validated endpoint: http://10.129.255.154:8000/
```

